### PR TITLE
chore: notify on deploy smoke failures

### DIFF
--- a/.github/instructions/copilot-review.instructions.md
+++ b/.github/instructions/copilot-review.instructions.md
@@ -6,7 +6,7 @@ When reviewing this repository, please focus on:
 - GitHub Actions workflow correctness and consistency.
 - Avoiding whitespace-only lines or trailing spaces in `run: |` blocks.
 
-This PR also adds an incident-notification job (commonly named `notify-failure`). Please confirm:
+If a pull request adds an incident-notification job (commonly named `notify-failure`), please confirm:
 
 - It runs only when the deploy job fails (via `always()` + `needs.<job>.result == 'failure'`).
 - It uses least-privilege permissions (typically just `issues: write`; omit `contents: read` unless the job reads repo contents).

--- a/.github/instructions/copilot-review.instructions.md
+++ b/.github/instructions/copilot-review.instructions.md
@@ -21,3 +21,5 @@ For any "post-deploy smoke check" step, confirm it:
 
 If you see issues outside this scope, mention them briefly.
 Don't block the PR unless they are security or correctness bugs.
+
+<!-- Copilot review wave: 2026-03-25T03:31:43.7766799Z -->

--- a/.github/instructions/copilot-review.instructions.md
+++ b/.github/instructions/copilot-review.instructions.md
@@ -22,4 +22,4 @@ For any "post-deploy smoke check" step, confirm it:
 If you see issues outside this scope, mention them briefly.
 Don't block the PR unless they are security or correctness bugs.
 
-<!-- Copilot review wave: 2026-03-25T03:56:27.6681381Z -->
+<!-- Copilot review wave: 2026-03-25T04:09:50.3014577Z -->

--- a/.github/instructions/copilot-review.instructions.md
+++ b/.github/instructions/copilot-review.instructions.md
@@ -22,4 +22,4 @@ For any "post-deploy smoke check" step, confirm it:
 If you see issues outside this scope, mention them briefly.
 Don't block the PR unless they are security or correctness bugs.
 
-<!-- Copilot review wave: 2026-03-25T03:31:43.7766799Z -->
+<!-- Copilot review wave: 2026-03-25T03:43:34.8598190Z -->

--- a/.github/instructions/copilot-review.instructions.md
+++ b/.github/instructions/copilot-review.instructions.md
@@ -22,4 +22,4 @@ For any "post-deploy smoke check" step, confirm it:
 If you see issues outside this scope, mention them briefly.
 Don't block the PR unless they are security or correctness bugs.
 
-<!-- Copilot review wave: 2026-03-25T04:18:32.7657165Z -->
+<!-- Copilot review wave: 2026-03-25T04:25:06.8454302Z -->

--- a/.github/instructions/copilot-review.instructions.md
+++ b/.github/instructions/copilot-review.instructions.md
@@ -6,6 +6,12 @@ When reviewing this repository, please focus on:
 - GitHub Actions workflow correctness and consistency.
 - Avoiding whitespace-only lines or trailing spaces in `run: |` blocks.
 
+This PR also adds an incident-notification job (commonly named `notify-failure`). Please confirm:
+
+- It runs only when the deploy job fails (via `always()` + `needs.<job>.result == 'failure'`).
+- It uses least-privilege permissions (typically `issues: write` and `contents: read`).
+- It links to the failing run and avoids printing any secrets.
+
 For any "post-deploy smoke check" step, confirm it:
 
 - Runs in the job that has access to the deployed URL.

--- a/.github/instructions/copilot-review.instructions.md
+++ b/.github/instructions/copilot-review.instructions.md
@@ -22,4 +22,4 @@ For any "post-deploy smoke check" step, confirm it:
 If you see issues outside this scope, mention them briefly.
 Don't block the PR unless they are security or correctness bugs.
 
-<!-- Copilot review wave: 2026-03-25T03:43:34.8598190Z -->
+<!-- Copilot review wave: 2026-03-25T03:56:27.6681381Z -->

--- a/.github/instructions/copilot-review.instructions.md
+++ b/.github/instructions/copilot-review.instructions.md
@@ -9,7 +9,7 @@ When reviewing this repository, please focus on:
 This PR also adds an incident-notification job (commonly named `notify-failure`). Please confirm:
 
 - It runs only when the deploy job fails (via `always()` + `needs.<job>.result == 'failure'`).
-- It uses least-privilege permissions (typically `issues: write` and `contents: read`).
+- It uses least-privilege permissions (typically just `issues: write`; omit `contents: read` unless the job reads repo contents).
 - It links to the failing run and avoids printing any secrets.
 
 For any "post-deploy smoke check" step, confirm it:

--- a/.github/instructions/copilot-review.instructions.md
+++ b/.github/instructions/copilot-review.instructions.md
@@ -22,4 +22,4 @@ For any "post-deploy smoke check" step, confirm it:
 If you see issues outside this scope, mention them briefly.
 Don't block the PR unless they are security or correctness bugs.
 
-<!-- Copilot review wave: 2026-03-25T04:09:50.3014577Z -->
+<!-- Copilot review wave: 2026-03-25T04:18:32.7657165Z -->

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -159,3 +159,50 @@ jobs:
                   sys.exit(1)
               time.sleep(min(delay_seconds, remaining))
           PY
+
+
+  notify-failure:
+    name: Notify on production deploy failure
+    needs: [deploy]
+    if: ${{ always() && needs.deploy.result == 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Create incident issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const shortSha = context.sha.substring(0, 7);
+            const labels = ["incident", "deployment"];
+
+            for (const name of labels) {
+              try {
+                await github.rest.issues.createLabel({ owner, repo, name, color: "B60205" });
+              } catch (e) {
+                // 422 = already exists
+                if (e.status !== 422) throw e;
+              }
+            }
+
+            const title = `Production deployment failed (${shortSha})`;
+            const body = [
+              `Workflow run: ${runUrl}`,
+              "",
+              `Ref: ${context.ref}`,
+              `SHA: ${context.sha}`,
+              "",
+              "_This issue was automatically created by the deploy workflow._",
+            ].join("\n");
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+              labels,
+            });

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,8 +163,8 @@ jobs:
 
   notify-failure:
     name: Notify on production deploy failure
-    needs: [build, deploy]
-    if: ${{ always() && (needs.build.result == 'failure' || needs.deploy.result == 'failure') && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') }}
+    needs: [build]
+    if: ${{ always() && needs.build.result == 'failure' && github.event_name != 'pull_request' && (github.event_name == 'workflow_run' || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -185,8 +185,8 @@ jobs:
               : (context.ref && context.ref.startsWith("refs/heads/") ? context.ref.substring("refs/heads/".length) : context.ref);
             const shortSha = (sha || "").substring(0, 7);
 
-            if (!isWorkflowRun && branch !== "main") {
-              core.info(`Skipping incident creation for non-main workflow_dispatch ref: ${branch}`);
+            if (branch !== "main") {
+              core.info(`Skipping incident creation for event "${context.eventName}" on non-main ref: ${branch}`);
               return;
             }
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -249,17 +249,25 @@ jobs:
                 core.warning(`Search API failed for dedupe: ${e && e.message ? e.message : e}`);
               }
 
-              // Fallback: list the first page of open issues and match by title + marker.
+              // Fallback: page through open issues (bounded) and match by title + marker.
               try {
-                const list = await github.rest.issues.listForRepo({
-                  owner,
-                  repo,
-                  state: "open",
-                  per_page: 100,
-                });
-                const openIssues = (list && list.data ? list.data : []).filter((item) => !item.pull_request);
-                const dup = openIssues.find((issue) => (issue.title || "") === title && (issue.body || "").includes(marker));
-                return dup ? dup.number : null;
+                const perPage = 100;
+                const maxPages = 10;
+                for (let page = 1; page <= maxPages; page++) {
+                  const list = await github.rest.issues.listForRepo({
+                    owner,
+                    repo,
+                    state: "open",
+                    per_page: perPage,
+                    page,
+                  });
+                  const data = (list && list.data) ? list.data : [];
+                  const openIssues = data.filter((item) => !item.pull_request);
+                  const dup = openIssues.find((issue) => (issue.title || "") === title && (issue.body || "").includes(marker));
+                  if (dup) return dup.number;
+                  if (data.length < perPage) break;
+                }
+                return null;
               } catch (e) {
                 core.warning(`Could not list existing issues for dedupe: ${e && e.message ? e.message : e}`);
                 return null;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,14 +185,31 @@ jobs:
               ? workflowRun.head_branch
               : (context.ref && context.ref.startsWith("refs/heads/") ? context.ref.substring("refs/heads/".length) : context.ref);
 
-            const labels = ["incident", "deployment"];
-            for (const name of labels) {
-              try {
-                await github.rest.issues.createLabel({ owner, repo, name, color: "B60205" });
-              } catch (e) {
-                if (e && e.status === 422) continue;
-                core.warning(`Could not create label "${name}": ${e && e.message ? e.message : e}`);
+            const incidentLabelSpecs = [
+              { name: "incident", color: "B60205" },
+              { name: "deployment", color: "B60205" },
+            ];
+            const incidentLabels = incidentLabelSpecs.map((l) => l.name);
+            const marker = "<!-- ffc-incident:prod-deploy-failure -->";
+
+            // Best-effort: ensure labels exist without spamming 422s every run.
+            try {
+              const existing = await github.paginate(github.rest.issues.listLabelsForRepo, {
+                owner,
+                repo,
+                per_page: 100,
+              });
+              const existingNames = new Set((existing || []).map((l) => l && l.name).filter(Boolean));
+              for (const spec of incidentLabelSpecs) {
+                if (existingNames.has(spec.name)) continue;
+                try {
+                  await github.rest.issues.createLabel({ owner, repo, name: spec.name, color: spec.color });
+                } catch (e) {
+                  core.warning(`Could not create label "${spec.name}": ${e && e.message ? e.message : e}`);
+                }
               }
+            } catch (e) {
+              core.warning(`Could not list/create labels: ${e && e.message ? e.message : e}`);
             }
 
             const title = `Production deployment failed (${branch})`;
@@ -207,49 +224,87 @@ jobs:
               `Ref: ${branch}`,
               `SHA: ${sha}`,
               "",
+              marker,
               "_This issue was automatically created by the deploy workflow._"
             );
             const body = bodyLines.join("\n");
 
-            let openIssues = [];
-            try {
-              const allItems = await github.paginate(github.rest.issues.listForRepo, {
-                owner,
-                repo,
-                state: "open",
-                per_page: 100,
-              });
-              openIssues = (allItems || []).filter((item) => !item.pull_request);
-            } catch (e) {
-              core.warning(`Could not list existing issues for dedupe: ${e && e.message ? e.message : e}`);
+            async function findDuplicateIssueNumber() {
+              const escapedTitle = title.replace(/"/g, "\\\"");
+              const q = `repo:${owner}/${repo} is:issue is:open in:title "${escapedTitle}" label:incident label:deployment`;
+              try {
+                const res = await github.rest.search.issuesAndPullRequests({ q, per_page: 10 });
+                const items = (res && res.data && res.data.items) ? res.data.items : [];
+                const match = items.find((item) => !item.pull_request && (item.title || "") === title);
+                if (match) {
+                  try {
+                    const full = await github.rest.issues.get({ owner, repo, issue_number: match.number });
+                    const fullBody = (full && full.data && full.data.body) ? full.data.body : "";
+                    if (fullBody.includes(marker)) return match.number;
+                  } catch (e) {
+                    core.warning(`Could not validate duplicate issue body: ${e && e.message ? e.message : e}`);
+                    return match.number;
+                  }
+                }
+              } catch (e) {
+                core.warning(`Search API failed for dedupe: ${e && e.message ? e.message : e}`);
+              }
+
+              // Fallback: list only labeled open issues (server-side filter) and match title.
+              try {
+                const allItems = await github.paginate(github.rest.issues.listForRepo, {
+                  owner,
+                  repo,
+                  state: "open",
+                  labels: incidentLabels.join(","),
+                  per_page: 100,
+                });
+                const openIssues = (allItems || []).filter((item) => !item.pull_request);
+                const dup = openIssues.find((issue) => (issue.title || "") === title);
+                return dup ? dup.number : null;
+              } catch (e) {
+                core.warning(`Could not list existing issues for dedupe: ${e && e.message ? e.message : e}`);
+                return null;
+              }
             }
 
-            const duplicate = openIssues.find((issue) => (issue.title || "") === title);
-
-            if (duplicate) {
-              core.info(`Incident issue #${duplicate.number} already exists; adding a comment.`);
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: duplicate.number,
-                body: [
-                  "Another deployment failure was detected:",
-                  "",
-                  body,
-                ].join("\n"),
-              });
+            const duplicateNumber = await findDuplicateIssueNumber();
+            if (duplicateNumber) {
+              core.info(`Incident issue #${duplicateNumber} already exists; adding a comment.`);
+              try {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: duplicateNumber,
+                  body: [
+                    "Another deployment failure was detected:",
+                    "",
+                    body,
+                  ].join("\n"),
+                });
+              } catch (e) {
+                core.warning(`Could not comment on incident issue: ${e && e.message ? e.message : e}`);
+              }
               return;
             }
 
-            const created = await github.rest.issues.create({
-              owner,
-              repo,
-              title,
-              body,
-            });
-
+            let created;
             try {
-              await github.rest.issues.addLabels({ owner, repo, issue_number: created.data.number, labels });
+              created = await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: incidentLabels,
+              });
             } catch (e) {
-              core.warning(`Could not apply labels to incident: ${e && e.message ? e.message : e}`);
+              core.warning(`Could not create labeled incident issue: ${e && e.message ? e.message : e}`);
+              try {
+                created = await github.rest.issues.create({ owner, repo, title, body });
+              } catch (e2) {
+                core.warning(`Could not create incident issue: ${e2 && e2.message ? e2.message : e2}`);
+                return;
+              }
             }
+
+            core.info(`Created incident issue #${created.data.number}`);

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,8 +163,8 @@ jobs:
 
   notify-failure:
     name: Notify on production deploy failure
-    needs: [build]
-    if: ${{ always() && needs.build.result == 'failure' && github.event_name != 'pull_request' && (github.event_name == 'workflow_run' || github.ref == 'refs/heads/main') }}
+    needs: [deploy]
+    if: ${{ always() && needs.deploy.result == 'failure' && (github.event_name == 'workflow_run' || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -184,7 +184,6 @@ jobs:
             const branch = isWorkflowRun
               ? workflowRun.head_branch
               : (context.ref && context.ref.startsWith("refs/heads/") ? context.ref.substring("refs/heads/".length) : context.ref);
-            const shortSha = (sha || "").substring(0, 7);
 
             if (branch !== "main") {
               core.info(`Skipping incident creation for event "${context.eventName}" on non-main ref: ${branch}`);

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,40 +164,85 @@ jobs:
   notify-failure:
     name: Notify on production deploy failure
     needs: [deploy]
-    if: ${{ always() && needs.deploy.result == 'failure' }}
+    if: ${{ always() && needs.deploy.result == 'failure' && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      contents: read
     steps:
       - name: Create incident issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const shortSha = context.sha.substring(0, 7);
-            const labels = ["incident", "deployment"];
 
+            const isWorkflowRun = context.eventName === "workflow_run";
+            const failedRunUrl = isWorkflowRun ? context.payload.workflow_run.html_url : `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const sha = isWorkflowRun ? context.payload.workflow_run.head_sha : context.sha;
+            const branch = isWorkflowRun
+              ? context.payload.workflow_run.head_branch
+              : (context.ref && context.ref.startsWith("refs/heads/") ? context.ref.substring("refs/heads/".length) : context.ref);
+            const shortSha = (sha || "").substring(0, 7);
+
+            if (!isWorkflowRun && branch !== "main") {
+              core.info(`Skipping incident creation for non-main workflow_dispatch ref: ${branch}`);
+              return;
+            }
+
+            const labels = ["incident", "deployment"];
             for (const name of labels) {
               try {
                 await github.rest.issues.createLabel({ owner, repo, name, color: "B60205" });
               } catch (e) {
-                // 422 = already exists
-                if (e.status !== 422) throw e;
+                if (e && e.status === 422) continue;
+                core.warning(`Could not create label "${name}": ${e && e.message ? e.message : e}`);
               }
             }
 
-            const title = `Production deployment failed (${shortSha})`;
+            const title = `Production deployment failed (${branch} @ ${shortSha})`;
             const body = [
-              `Workflow run: ${runUrl}`,
+              `Workflow run: ${failedRunUrl}`,
               "",
-              `Ref: ${context.ref}`,
-              `SHA: ${context.sha}`,
+              `Ref: ${branch}`,
+              `SHA: ${sha}`,
               "",
               "_This issue was automatically created by the deploy workflow._",
-            ].join("\n");
+            ].join("\\n");
+
+            let openIssues = [];
+            try {
+              const resp = await github.rest.issues.listForRepo({
+                owner,
+                repo,
+                state: "open",
+                labels: labels.join(","),
+                per_page: 100,
+              });
+              openIssues = resp.data || [];
+            } catch (e) {
+              core.warning(`Could not list existing issues for dedupe: ${e && e.message ? e.message : e}`);
+            }
+
+            const duplicate = openIssues.find((issue) => {
+              const issueTitle = issue.title || "";
+              const issueBody = issue.body || "";
+              return issueTitle === title || issueBody.includes(`Workflow run: ${failedRunUrl}`);
+            });
+
+            if (duplicate) {
+              core.info(`Incident issue #${duplicate.number} already exists; adding a comment.`);
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: duplicate.number,
+                body: [
+                  "Another deployment failure was detected:",
+                  "",
+                  body,
+                ].join("\\n"),
+              });
+              return;
+            }
 
             await github.rest.issues.create({
               owner,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -176,12 +176,13 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            const isWorkflowRun = context.eventName === "workflow_run";
+            const workflowRun = context.payload && context.payload.workflow_run;
+            const isWorkflowRun = Boolean(workflowRun);
             const deployRunUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const upstreamRunUrl = isWorkflowRun ? context.payload.workflow_run.html_url : null;
-            const sha = isWorkflowRun ? context.payload.workflow_run.head_sha : context.sha;
+            const upstreamRunUrl = isWorkflowRun ? workflowRun.html_url : null;
+            const sha = isWorkflowRun ? workflowRun.head_sha : context.sha;
             const branch = isWorkflowRun
-              ? context.payload.workflow_run.head_branch
+              ? workflowRun.head_branch
               : (context.ref && context.ref.startsWith("refs/heads/") ? context.ref.substring("refs/heads/".length) : context.ref);
             const shortSha = (sha || "").substring(0, 7);
 
@@ -200,7 +201,7 @@ jobs:
               }
             }
 
-            const title = `Production deployment failed (${branch} @ ${shortSha})`;
+            const title = `Production deployment failed (${branch})`;
             const bodyLines = [
               `Deploy run: ${deployRunUrl}`,
             ];
@@ -223,17 +224,25 @@ jobs:
                 repo,
                 state: "open",
                 per_page: 100,
+                labels: labels.join(","),
               });
               openIssues = (allItems || []).filter((item) => !item.pull_request);
             } catch (e) {
-              core.warning(`Could not list existing issues for dedupe: ${e && e.message ? e.message : e}`);
+              core.warning(`Could not list existing labeled issues for dedupe: ${e && e.message ? e.message : e}`);
+              try {
+                const allItems = await github.paginate(github.rest.issues.listForRepo, {
+                  owner,
+                  repo,
+                  state: "open",
+                  per_page: 100,
+                });
+                openIssues = (allItems || []).filter((item) => !item.pull_request);
+              } catch (e2) {
+                core.warning(`Could not list existing issues for dedupe: ${e2 && e2.message ? e2.message : e2}`);
+              }
             }
 
-            const duplicate = openIssues.find((issue) => {
-              const issueTitle = issue.title || "";
-              const issueBody = issue.body || "";
-              return issueTitle === title || issueBody.includes(`Deploy run: ${deployRunUrl}`);
-            });
+            const duplicate = openIssues.find((issue) => (issue.title || "") === title);
 
             if (duplicate) {
               core.info(`Incident issue #${duplicate.number} already exists; adding a comment.`);

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,36 +231,34 @@ jobs:
 
             async function findDuplicateIssueNumber() {
               const escapedTitle = title.replace(/"/g, "\\\"");
-              const q = `repo:${owner}/${repo} is:issue is:open in:title "${escapedTitle}" label:incident label:deployment`;
+              const q = `repo:${owner}/${repo} is:issue is:open in:title "${escapedTitle}"`;
               try {
                 const res = await github.rest.search.issuesAndPullRequests({ q, per_page: 10 });
                 const items = (res && res.data && res.data.items) ? res.data.items : [];
-                const match = items.find((item) => !item.pull_request && (item.title || "") === title);
-                if (match) {
+                const matches = items.filter((item) => !item.pull_request && (item.title || "") === title);
+                for (const m of matches) {
                   try {
-                    const full = await github.rest.issues.get({ owner, repo, issue_number: match.number });
+                    const full = await github.rest.issues.get({ owner, repo, issue_number: m.number });
                     const fullBody = (full && full.data && full.data.body) ? full.data.body : "";
-                    if (fullBody.includes(marker)) return match.number;
+                    if (fullBody.includes(marker)) return m.number;
                   } catch (e) {
-                    core.warning(`Could not validate duplicate issue body: ${e && e.message ? e.message : e}`);
-                    return match.number;
+                    core.warning(`Could not validate possible duplicate issue body: ${e && e.message ? e.message : e}`);
                   }
                 }
               } catch (e) {
                 core.warning(`Search API failed for dedupe: ${e && e.message ? e.message : e}`);
               }
 
-              // Fallback: list only labeled open issues (server-side filter) and match title.
+              // Fallback: list the first page of open issues and match by title + marker.
               try {
-                const allItems = await github.paginate(github.rest.issues.listForRepo, {
+                const list = await github.rest.issues.listForRepo({
                   owner,
                   repo,
                   state: "open",
-                  labels: incidentLabels.join(","),
                   per_page: 100,
                 });
-                const openIssues = (allItems || []).filter((item) => !item.pull_request);
-                const dup = openIssues.find((issue) => (issue.title || "") === title);
+                const openIssues = (list && list.data ? list.data : []).filter((item) => !item.pull_request);
+                const dup = openIssues.find((issue) => (issue.title || "") === title && (issue.body || "").includes(marker));
                 return dup ? dup.number : null;
               } catch (e) {
                 core.warning(`Could not list existing issues for dedupe: ${e && e.message ? e.message : e}`);

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,7 +177,8 @@ jobs:
             const repo = context.repo.repo;
 
             const isWorkflowRun = context.eventName === "workflow_run";
-            const failedRunUrl = isWorkflowRun ? context.payload.workflow_run.html_url : `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const deployRunUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const upstreamRunUrl = isWorkflowRun ? context.payload.workflow_run.html_url : null;
             const sha = isWorkflowRun ? context.payload.workflow_run.head_sha : context.sha;
             const branch = isWorkflowRun
               ? context.payload.workflow_run.head_branch
@@ -200,14 +201,20 @@ jobs:
             }
 
             const title = `Production deployment failed (${branch} @ ${shortSha})`;
-            const body = [
-              `Workflow run: ${failedRunUrl}`,
+            const bodyLines = [
+              `Deploy run: ${deployRunUrl}`,
+            ];
+            if (upstreamRunUrl) {
+              bodyLines.push(`Upstream run: ${upstreamRunUrl}`);
+            }
+            bodyLines.push(
               "",
               `Ref: ${branch}`,
               `SHA: ${sha}`,
               "",
-              "_This issue was automatically created by the deploy workflow._",
-            ].join("\\n");
+              "_This issue was automatically created by the deploy workflow._"
+            );
+            const body = bodyLines.join("\\n");
 
             let openIssues = [];
             try {
@@ -215,10 +222,9 @@ jobs:
                 owner,
                 repo,
                 state: "open",
-                labels: labels.join(","),
                 per_page: 100,
               });
-              openIssues = resp.data || [];
+              openIssues = (resp.data || []).filter((item) => !item.pull_request);
             } catch (e) {
               core.warning(`Could not list existing issues for dedupe: ${e && e.message ? e.message : e}`);
             }
@@ -226,7 +232,7 @@ jobs:
             const duplicate = openIssues.find((issue) => {
               const issueTitle = issue.title || "";
               const issueBody = issue.body || "";
-              return issueTitle === title || issueBody.includes(`Workflow run: ${failedRunUrl}`);
+              return issueTitle === title || issueBody.includes(`Deploy run: ${deployRunUrl}`);
             });
 
             if (duplicate) {
@@ -244,10 +250,17 @@ jobs:
               return;
             }
 
-            await github.rest.issues.create({
+            const created = await github.rest.issues.create({
               owner,
               repo,
               title,
               body,
-              labels,
             });
+
+            for (const name of labels) {
+              try {
+                await github.rest.issues.addLabels({ owner, repo, issue_number: created.data.number, labels: [name] });
+              } catch (e) {
+                core.warning(`Could not apply label "${name}" to incident: ${e && e.message ? e.message : e}`);
+              }
+            }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,8 +163,8 @@ jobs:
 
   notify-failure:
     name: Notify on production deploy failure
-    needs: [deploy]
-    if: ${{ always() && needs.deploy.result == 'failure' && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') }}
+    needs: [build, deploy]
+    if: ${{ always() && (needs.build.result == 'failure' || needs.deploy.result == 'failure') && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -214,17 +214,17 @@ jobs:
               "",
               "_This issue was automatically created by the deploy workflow._"
             );
-            const body = bodyLines.join("\\n");
+            const body = bodyLines.join("\n");
 
             let openIssues = [];
             try {
-              const resp = await github.rest.issues.listForRepo({
+              const allItems = await github.paginate(github.rest.issues.listForRepo, {
                 owner,
                 repo,
                 state: "open",
                 per_page: 100,
               });
-              openIssues = (resp.data || []).filter((item) => !item.pull_request);
+              openIssues = (allItems || []).filter((item) => !item.pull_request);
             } catch (e) {
               core.warning(`Could not list existing issues for dedupe: ${e && e.message ? e.message : e}`);
             }
@@ -245,7 +245,7 @@ jobs:
                   "Another deployment failure was detected:",
                   "",
                   body,
-                ].join("\\n"),
+                ].join("\n"),
               });
               return;
             }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,7 +164,7 @@ jobs:
   notify-failure:
     name: Notify on production deploy failure
     needs: [deploy]
-    if: ${{ always() && needs.deploy.result == 'failure' && (github.event_name == 'workflow_run' || github.ref == 'refs/heads/main') }}
+    if: ${{ always() && needs.deploy.result == 'failure' && (github.event_name != 'workflow_run' || github.event.workflow_run.head_branch == 'main') && (github.event_name == 'workflow_run' || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -184,11 +184,6 @@ jobs:
             const branch = isWorkflowRun
               ? workflowRun.head_branch
               : (context.ref && context.ref.startsWith("refs/heads/") ? context.ref.substring("refs/heads/".length) : context.ref);
-
-            if (branch !== "main") {
-              core.info(`Skipping incident creation for event "${context.eventName}" on non-main ref: ${branch}`);
-              return;
-            }
 
             const labels = ["incident", "deployment"];
             for (const name of labels) {
@@ -223,22 +218,10 @@ jobs:
                 repo,
                 state: "open",
                 per_page: 100,
-                labels: labels.join(","),
               });
               openIssues = (allItems || []).filter((item) => !item.pull_request);
             } catch (e) {
-              core.warning(`Could not list existing labeled issues for dedupe: ${e && e.message ? e.message : e}`);
-              try {
-                const allItems = await github.paginate(github.rest.issues.listForRepo, {
-                  owner,
-                  repo,
-                  state: "open",
-                  per_page: 100,
-                });
-                openIssues = (allItems || []).filter((item) => !item.pull_request);
-              } catch (e2) {
-                core.warning(`Could not list existing issues for dedupe: ${e2 && e2.message ? e2.message : e2}`);
-              }
+              core.warning(`Could not list existing issues for dedupe: ${e && e.message ? e.message : e}`);
             }
 
             const duplicate = openIssues.find((issue) => (issue.title || "") === title);
@@ -265,10 +248,8 @@ jobs:
               body,
             });
 
-            for (const name of labels) {
-              try {
-                await github.rest.issues.addLabels({ owner, repo, issue_number: created.data.number, labels: [name] });
-              } catch (e) {
-                core.warning(`Could not apply label "${name}" to incident: ${e && e.message ? e.message : e}`);
-              }
+            try {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: created.data.number, labels });
+            } catch (e) {
+              core.warning(`Could not apply labels to incident: ${e && e.message ? e.message : e}`);
             }


### PR DESCRIPTION
Adds a notify-failure job to the GitHub Pages deploy workflow. When the deploy job fails (including post-deploy smoke check failures), it automatically opens an incident issue with a link to the failing workflow run.